### PR TITLE
Ignore warnings regarding partial indices on postgresql schemas

### DIFF
--- a/gensaschema/_table.py
+++ b/gensaschema/_table.py
@@ -168,6 +168,8 @@ class Table(object):
                                      message=r'^Skipped unsupported '
                                              r'reflection of expression-based'
                                              r' index ')
+            _warnings.filterwarnings('ignore', category=_sa.exc.SAWarning,
+                                     message=r'^Predicate of partial index ')
 
             table = _sa.Table(name, metadata, autoload=True, **kwargs)
             # while 1:


### PR DESCRIPTION
Creation of a DB schema failed with a SQLAlchemy warning

`sqlalchemy.exc.SAWarning: Predicate of partial index [idx_name] ignored during reflection`

the additional `filterwarnings` statement fixes this.
