### PR TITLE
Emit separate PG enum objects

### DIFF
--- a/docs/CHANGES
+++ b/docs/CHANGES
@@ -1,5 +1,7 @@
 Changes with version
 
+ *) Emit separate PG enum objects. Thanks to happyraul and armonge for the PRs.
+
  *) Run black formatter
 
  *) Update project boilerplate

--- a/gensaschema/_config.py
+++ b/gensaschema/_config.py
@@ -33,12 +33,12 @@ import errno as _errno
 if 1:
     try:
         import ConfigParser as _config_parser
-    except ImportError:  # pragma: no cover
+    except ImportError:
         import configparser as _config_parser
 
     try:
         from cStringIO import StringIO as _TextIO
-    except ImportError:  # pragma: no cover
+    except ImportError:
         from io import StringIO as _TextIO
 
 from . import _template

--- a/gensaschema/_constraint.py
+++ b/gensaschema/_constraint.py
@@ -196,7 +196,7 @@ def access_col(col):
     except AttributeError:
         name = col
     try:
-        if _util.py2 and isinstance(name, _util.bytes):  # pragma: no cover
+        if _util.py2 and isinstance(name, _util.bytes):
             name.decode('ascii')
         else:
             name.encode('ascii')

--- a/gensaschema/_exceptions.py
+++ b/gensaschema/_exceptions.py
@@ -55,7 +55,7 @@ class Warning(
     """
 
     @classmethod
-    def emit(cls, message, stacklevel=1):  # pragma: no cover
+    def emit(cls, message, stacklevel=1):
         """
         Emit a warning of this very category
 

--- a/gensaschema/_table.py
+++ b/gensaschema/_table.py
@@ -159,6 +159,9 @@ class Table(object):
             responsible for modifying the symbols and imports *and* the
             dialect's ``ischema_names``. If omitted or ``None``, the reflector
             will always fail on unknown types.
+
+        Returns:
+          Table: new Table instance
         """
         kwargs = {}
         if '.' in name:
@@ -370,9 +373,7 @@ class TableCollection(tuple):
             """Map SA table to table object"""
             if sa_table.key not in objects:
                 varname = sa_table.name
-                if _util.py2 and isinstance(
-                    varname, _util.unicode
-                ):  # pragma: no cover
+                if _util.py2 and isinstance(varname, _util.unicode):
                     varname = varname.encode('ascii')
                 objects[sa_table.key] = Table(
                     varname, sa_table, schemas, symbols

--- a/gensaschema/_util.py
+++ b/gensaschema/_util.py
@@ -31,25 +31,25 @@ __author__ = u"Andr\xe9 Malo"
 # pylint: disable = redefined-builtin, invalid-name, self-assigning-variable
 try:
     unicode  # pylint: disable = used-before-assignment
-except NameError:  # pragma: no cover
+except NameError:
     unicode = str
-else:  # pragma: no cover
+else:
     unicode = unicode
 
 try:
     bytes  # pylint: disable = used-before-assignment
-except NameError:  # pragma: no cover
+except NameError:
     bytes = str
-else:  # pragma: no cover
+else:
     bytes = bytes
 
 py2 = bytes is str
 
 try:
     cmp  # pylint: disable = used-before-assignment
-except NameError:  # pragma: no cover
+except NameError:
     cmp = lambda a, b: (a > b) - (a < b)
-else:  # pragma: no cover
+else:
     cmp = cmp
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+# -*- coding: ascii -*-
+u"""
+:Copyright:
+
+ Copyright 2023
+ Andr\xe9 Malo or his licensors, as applicable
+
+:License:
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+============
+ Test setup
+============
+
+Test setup
+"""
+__author__ = u"Andr\xe9 Malo, Andr\xe9s Reyes Monge"
+
+import time as _time
+
+import docker as _docker
+import pytest as _pytest
+
+POSTGRES_PASSWORD = "supersecretpassword"
+POSTGRES_PORT = 65432
+POSTGRES_USER = "postgres"
+POSTGRES_DB = "postgres"
+POSTGRES_HOST = "127.0.0.1"
+
+
+def _wait_for_postgres_init(container):
+    while True:
+        _time.sleep(1)
+        logs = container.logs().decode("ascii")
+        if (
+            "PostgreSQL init process complete; ready for start up."
+            not in logs
+        ):
+            continue
+
+        last_log = logs.splitlines()[-1]
+        if "database system is ready to accept connections" not in last_log:
+            continue
+
+        break
+
+
+@_pytest.fixture(
+    name="postgres_docker",
+    params=[11, 12, 13, 14, 15],
+    ids=[
+        "postgres_v11",
+        "postgres_v12",
+        "postgres_v13",
+        "postgres_v14",
+        "postgres_v15",
+    ],
+)
+def postgres_docker_fixture(request):
+    """Start a postgres DB"""
+    client = _docker.from_env()
+    postgres_version = request.param
+    container = client.containers.run(
+        image="postgres:{version}".format(version=postgres_version),
+        auto_remove=True,
+        environment=dict(
+            POSTGRES_PASSWORD=POSTGRES_PASSWORD,
+        ),
+        name="postgres-test-%s" % postgres_version,
+        ports={"5432/tcp": (POSTGRES_HOST, POSTGRES_PORT)},
+        detach=True,
+        remove=True,
+    )
+
+    _wait_for_postgres_init(container)
+
+    yield
+
+    container.stop()
+
+
+@_pytest.fixture()
+def postgres_url(postgres_docker):
+    """Return connection URL for DB"""
+    # pylint: disable = unused-argument
+
+    yield "postgresql+psycopg2://%s:%s@%s:%s/%s" % (
+        POSTGRES_USER,
+        POSTGRES_PASSWORD,
+        POSTGRES_HOST,
+        POSTGRES_PORT,
+        POSTGRES_DB,
+    )

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -1,4 +1,5 @@
 # -*- coding: ascii -*-
+# pylint: disable = line-too-long
 u"""
 :Copyright:
 
@@ -19,13 +20,13 @@ u"""
  See the License for the specific language governing permissions and
  limitations under the License.
 
-==============================
- Tests for gensaschema._table
-==============================
+=========================
+ Schema generation tests
+=========================
 
-Tests for gensaschema._table
+Schema generation tests
 """
-__author__ = u"Andr\xe9 Malo"
+__author__ = u"Andr\xe9 Malo, Andr\xe9s Reyes Monge"
 
 import os as _os
 import sys as _sys
@@ -242,3 +243,193 @@ del _sa, T, C, D, m
         exec(code, glob, loc)
     else:
         exec("exec result in glob, loc")
+
+
+def test_postgresql_schema_with_enums(postgres_url, tmpdir):
+    _warnings.simplefilter("error", _sa.exc.SAWarning)
+
+    tmpdir = str(tmpdir)
+    db = _sa.create_engine(postgres_url).connect()
+    try:
+        run = runner(db)
+        run(
+            """
+            CREATE TYPE card AS ENUM ('visa', 'mastercard', 'amex');
+            CREATE TABLE names (
+                id  serial PRIMARY KEY,
+                first  VARCHAR(128) DEFAULT NULL,
+                last   VARCHAR(129) NOT NULL,
+                card_types card ARRAY NOT NULL
+            );
+        """
+        )
+        run(
+            """
+            CREATE TABLE emails (
+                id  serial PRIMARY KEY,
+                address  VARCHAR(127) NOT NULL,
+
+                UNIQUE (address)
+            );
+        """
+        )
+        run(
+            """
+            CREATE TABLE addresses (
+                id  serial PRIMARY KEY,
+                zip_code  VARCHAR(32) DEFAULT NULL,
+                place     VARCHAR(78) NOT NULL,
+                street    VARCHAR(64) DEFAULT NULL
+            );
+        """
+        )
+        run(
+            """
+
+            CREATE TABLE persons (
+                id  serial PRIMARY KEY,
+                address  INT NOT NULL,
+                name  INT NOT NULL,
+                email  INT DEFAULT NULL,
+                card_types card ARRAY NOT NULL,
+
+                FOREIGN KEY (address) REFERENCES addresses (id),
+                FOREIGN KEY (name) REFERENCES names (id),
+                FOREIGN KEY (email) REFERENCES emails (id)
+            );
+        """
+        )
+        run(
+            """
+            ALTER TABLE addresses
+                ADD COLUMN owner INT DEFAULT NULL REFERENCES persons (id);
+        """
+        )
+        schema = _schema.Schema(
+            db,
+            [
+                ("names", "names"),
+                ("emails", "emails"),
+                ("addresses", "addresses"),
+                ("persons", "persons"),
+            ],
+            {},
+            _symbols.Symbols(dict(type="t")),
+            dbname="foo",
+        )
+    finally:
+        db.close()
+
+    with open(_os.path.join(tmpdir, "schema.py"), "w") as fp:
+        schema.dump(fp)
+
+    with open(_os.path.join(tmpdir, "schema.py")) as fp:
+        result = fp.read()
+
+    expected = (
+        '''
+# -*- coding: ascii -*-
+# flake8: noqa pylint: skip-file
+"""
+==============================
+ SQLAlchemy schema definition
+==============================
+
+SQLAlchemy schema definition for foo.
+
+:Warning: DO NOT EDIT, this file is generated
+"""
+
+import sqlalchemy as _sa
+from sqlalchemy.dialects import postgresql as t
+from gensaschema.constraints import ForeignKey as ForeignKey
+from gensaschema.constraints import PrimaryKey as PrimaryKey
+from gensaschema.constraints import Unique as Unique
+
+m = _sa.MetaData()
+T = _sa.Table
+C = _sa.Column
+D = _sa.DefaultClause
+
+# Custom type definitions
+enum_card = t.ENUM(u'visa', u'mastercard', u'amex', name='card')
+
+# Table "addresses"
+addresses = T(u'addresses', m,
+    C('id', t.INTEGER, nullable=False, server_default=D(u"nextval('addresses_id_seq'::regclass)")),
+    C('zip_code', t.VARCHAR(32), server_default=D(u'NULL::character varying')),
+    C('place', t.VARCHAR(78), nullable=False),
+    C('street', t.VARCHAR(64), server_default=D(u'NULL::character varying')),
+    C('owner', t.INTEGER),
+)
+PrimaryKey(addresses.c.id, name=u'addresses_pkey')
+
+# Defined at table 'persons':
+# ForeignKey(
+#     [addresses.c.owner],
+#     [persons.c.id],
+#     name=u'addresses_owner_fkey',
+# )
+
+
+# Table "emails"
+emails = T(u'emails', m,
+    C('id', t.INTEGER, nullable=False, server_default=D(u"nextval('emails_id_seq'::regclass)")),
+    C('address', t.VARCHAR(127), nullable=False),
+)
+PrimaryKey(emails.c.id, name=u'emails_pkey')
+Unique(emails.c.address, name=u'emails_address_key')
+
+
+# Table "names"
+names = T(u'names', m,
+    C('id', t.INTEGER, nullable=False, server_default=D(u"nextval('names_id_seq'::regclass)")),
+    C('first', t.VARCHAR(128), server_default=D(u'NULL::character varying')),
+    C('last', t.VARCHAR(129), nullable=False),
+    C('card_types', t.ARRAY(enum_card), nullable=False),
+)
+PrimaryKey(names.c.id, name=u'names_pkey')
+
+
+# Table "persons"
+persons = T(u'persons', m,
+    C('id', t.INTEGER, nullable=False, server_default=D(u"nextval('persons_id_seq'::regclass)")),
+    C('address', t.INTEGER, nullable=False),
+    C('name', t.INTEGER, nullable=False),
+    C('email', t.INTEGER),
+    C('card_types', t.ARRAY(enum_card), nullable=False),
+)
+PrimaryKey(persons.c.id, name=u'persons_pkey')
+ForeignKey(
+    [persons.c.address],
+    [addresses.c.id],
+    name=u'persons_address_fkey',
+)
+ForeignKey(
+    [persons.c.email],
+    [emails.c.id],
+    name=u'persons_email_fkey',
+)
+ForeignKey(
+    [persons.c.name],
+    [names.c.id],
+    name=u'persons_name_fkey',
+)
+
+# Foreign key belongs to 'addresses':
+ForeignKey(
+    [addresses.c.owner],
+    [persons.c.id],
+    name=u'addresses_owner_fkey',
+)
+
+
+del _sa, T, C, D, m
+
+# vim: nowrap tw=0
+    '''.strip()
+        + "\n"
+    )
+    if bytes is not str:
+        expected = expected.replace("u'", "'").replace('u"', '"')
+    assert result == expected

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -15,3 +15,10 @@ coverage == 5.5; python_version < '3.6'
 pytest-mock == 3.11.1; python_version >= '3.7'
 pytest-mock == 3.6.1; python_version == '3.6'
 pytest-mock == 1.12.1; python_version < '3.6'
+
+psycopg2 ~= 2.9.6; python_version >= '3.6'
+psycopg2 ~= 2.8.6; python_version < '3.6'
+
+docker ~= 6.1.3; python_version >= '3.7'
+docker ~= 5.0.3; python_version == '3.6'
+docker ~= 4.4.4; python_version < '3.6'


### PR DESCRIPTION
# Description

When generating a SQLAlchemy schema for Postgres database the Enum definitions where not correctly added as separate custom type definitions. This meant that when using an enum, SQLAlchemy would crash with the following exception:

```python
    def format_type(self, type_, use_schema=True):
        if not type_.name:
>           raise exc.CompileError("PostgreSQL ENUM type requires a name.")
E           sqlalchemy.exc.CompileError: PostgreSQL ENUM type requires a name.
```

The changes to the schema are as follows:

Previous: 


```python
# Table "t_table"
t_table = T('t_table', m,
    C('a_id', t.INTEGER, nullable=False, server_default=D("nextval('t_table_a_id_seq'::regclass)")),
    C('a_status', t.ENUM('active', 'inactive'), nullable=False),
)
```

Current: 
```python
# Custom type definitions
enum_e_status = t.ENUM('active', 'inactive', name='e_status')

# Table "t_table"
t_table = T('t_table', m,
    C('a_id', t.INTEGER, nullable=False, server_default=D("nextval('t_table_a_id_seq'::regclass)")),
    C('a_status', enum_e_status, nullable=False)
)

```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules